### PR TITLE
Potential fix for code scanning alert no. 66: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/PathTraversalVulnerability.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/PathTraversalVulnerability.java
@@ -20,8 +20,14 @@ public class PathTraversalVulnerability {
 
     @GetMapping("/read")
     public void readFile(@RequestParam("filename") String filename, HttpServletResponse response) throws IOException {
-        // Vulnerable: does not sanitize user input, allowing path traversal
-        File file = new File(BASE_DIRECTORY + filename);
+        // Validate user input: ensure resulting path stays within base directory
+        java.nio.file.Path basePath = java.nio.file.Paths.get(BASE_DIRECTORY).toAbsolutePath().normalize();
+        java.nio.file.Path requestedPath = basePath.resolve(filename).normalize();
+        File file = requestedPath.toFile();
+        if (!requestedPath.startsWith(basePath)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid filename");
+            return;
+        }
         if (file.exists() && file.isFile()) {
             try (FileInputStream fis = new FileInputStream(file);
                  OutputStream os = response.getOutputStream()) {


### PR DESCRIPTION
Potential fix for [https://github.com/KPMG-Demo-Organization/WebGoat/security/code-scanning/66](https://github.com/KPMG-Demo-Organization/WebGoat/security/code-scanning/66) from the [WebGoat -August Campaign](https://github.com/orgs/KPMG-Demo-Organization/security/campaigns/5) security campaign.

To fix the vulnerability, we should validate the user input before constructing a file path. The single best approach here is to ensure the resolved file path stays within the intended base directory, regardless of whether the user attempts to supply traversal sequences like `../`. This is done by resolving the user input against the base directory, normalizing the result (which resolves any `..` and similar segments), and then checking that the normalized absolute path starts with the base directory's normalized absolute path. 

The required changes are:
- Use `java.nio.file.Path` to safely join and normalize paths.
- Check that the resulting file path starts with the base directory's normalized absolute path.
- Only allow file access if this check passes.
- Otherwise, respond with an error.

No external dependencies are required; only built-in Java libraries are needed (which are already imported in the shown code).

Changes needed:
- Edit the `readFile` method in `PathTraversalVulnerability.java`, rewrite the file path construction and validation logic.
- If not already imported, import `java.nio.file.Path` and `java.nio.file.Paths`. But since only standard imports are allowed, add them if not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
